### PR TITLE
[กิตติภณ] feat: DELETE /api/notifications/:id และ POST /api/notifications/send

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,95 @@
-กลุ่ม QFlow
+# QFlow — Queue Management API
 
-Queue Booking Module
+ระบบจัดการคิวออนไลน์ พัฒนาด้วย Go (net/http) สำหรับวิชา CS367 Web Service Development Concepts
 
-ชื่อ กิตติธัช เด่นสกุลประเสริฐ
+---
 
-- POST /api/queues/book จองคิว → เลขคิว
+## สมาชิกกลุ่มและการแบ่งงาน
 
-- GET /api/queues/:queueNumber ดูสถานะคิว
+### Queue Booking Module
 
-ชื่อ พิรญาณ์ เอนอ่อน
+| ชื่อ | งานที่รับผิดชอบ | Branch |
+|------|----------------|--------|
+| กิตติธัช เด่นสกุลประเสริฐ | `POST /api/queues/book` จองคิว, `GET /api/queues/:queueNumber` ดูสถานะคิว, **Unit Test: Queue Booking** | `feature/queue-booking` |
+| พิรญาณ์ เอนอ่อน | `GET /api/queues/history` ประวัติการจอง, `PATCH /api/queues/:id/cancel` ยกเลิกคิว, **Unit Test: Queue History & Cancel** | `feature/queue-history-cancel` |
 
-- GET /api/queues/history ประวัติการจอง
+### Queue Management Module
 
-- PATCH /api/queues/:id/cancel ยกเลิกคิว
+| ชื่อ | งานที่รับผิดชอบ | Branch |
+|------|----------------|--------|
+| ณัฏฐ์ ศรีสุวรรณกุล | `GET /api/manage/queues/:zoneId` ดูรายการคิวในโซน, `PATCH /api/manage/queues/:id/call` เรียกคิว + แจ้งเตือน, **Unit Test: Queue Call** | `feature/manage-queue-call` |
+| ธนกฤต พิบูลย์สวัสดิ์ | `PATCH /api/manage/queues/:id/complete` ปิดคิว, `PATCH /api/manage/queues/:id/skip` ข้ามคิว, **Docker (Dockerfile + docker-compose)** | `feature/manage-queue-complete-skip` |
 
-Queue Management
+### Notification Module
 
-ชื่อ ณัฏฐ์ ศรีสุวรรณกุล
+| ชื่อ | งานที่รับผิดชอบ | Branch |
+|------|----------------|--------|
+| พชร พรพงศ์ | `GET /api/notifications` ดูแจ้งเตือนทั้งหมด, `PATCH /api/notifications/:id/read` อ่านการแจ้งเตือน, **JWT Authentication Middleware** | `feature/notification-read` |
+| กิตติภณ คำนวล | `DELETE /api/notifications/:id` ลบแจ้งเตือน, `POST /api/notifications/send` ส่งการแจ้งเตือน, **Database (เชื่อมต่อ DB + Schema)** | `feature/notification-delete-send` |
 
-- GET /api/manage/queues/:zoneId ดูรายการคิวทั้งหมดในโซน
+---
 
-- PATCH /api/manage/queues/:id/call เรียกคิว + แจ้งเตือน
+## API Endpoints
 
-ชื่อ ธนกฤต พิบูลย์สวัสดิ์
+### Queue Booking
+| Method | Endpoint | คำอธิบาย |
+|--------|----------|----------|
+| `POST` | `/api/queues/book` | จองคิว → ได้รับเลขคิว |
+| `GET` | `/api/queues/:queueNumber` | ดูสถานะคิว |
+| `GET` | `/api/queues/history` | ประวัติการจองทั้งหมด |
+| `PATCH` | `/api/queues/:id/cancel` | ยกเลิกคิว |
 
-- PATCH /api/manage/queues/:id/complete ปิดคิว (เสร็จสิ้น)
+### Queue Management
+| Method | Endpoint | คำอธิบาย |
+|--------|----------|----------|
+| `GET` | `/api/manage/queues/:zoneId` | ดูรายการคิวทั้งหมดในโซน |
+| `PATCH` | `/api/manage/queues/:id/call` | เรียกคิว + แจ้งเตือน |
+| `PATCH` | `/api/manage/queues/:id/complete` | ปิดคิว (เสร็จสิ้น) |
+| `PATCH` | `/api/manage/queues/:id/skip` | ข้ามคิว |
 
-- PATCH /api/manage/queues/:id/skip ข้ามคิว
- 
-Notification Module
+### Notifications
+| Method | Endpoint | คำอธิบาย |
+|--------|----------|----------|
+| `GET` | `/api/notifications` | ดูแจ้งเตือนทั้งหมด |
+| `PATCH` | `/api/notifications/:id/read` | ทำเครื่องหมายว่าอ่านแล้ว |
+| `DELETE` | `/api/notifications/:id` | ลบแจ้งเตือน |
+| `POST` | `/api/notifications/send` | ส่งการแจ้งเตือน (ระบบ) |
 
-ชื่อ พชร พรพงศ์
+---
 
-- GET /api/notifications ดูแจ้งเตือนทั้งหมด (User)
+## Tech Stack
 
-- PATCH /api/notifications/:id/read อ่านการแจ้งเตือน
+- **Language:** Go
+- **Database:** (TBD)
+- **Auth:** JWT
+- **Container:** Docker
 
-ชื่อ กิตติภณ คำนวล
+---
 
-- DELETE /api/notifications/:id ลบแจ้งเตือน
+## วิธีการติดตั้งและรัน
 
-- POST /api/notifications/send ส่งการแจ้งเตือนไปยัง User  (ระบบ)
+### รันด้วย Go
+```bash
+go run main.go
+```
+Server จะรันที่ `http://localhost:3000`
+
+### รันด้วย Docker
+```bash
+docker-compose up --build
+```
+
+---
+
+## Git Workflow
+
+```
+main        ← final version (merge จาก develop เมื่อเสร็จสิ้น)
+develop     ← รวมงานจากทุก feature branch
+feature/*   ← พัฒนาแต่ละ feature
+```
+
+1. แต่ละคน checkout จาก `develop` ไปยัง `feature/<feature-name>`
+2. พัฒนาและ commit อย่างสม่ำเสมอ
+3. เปิด Pull Request เข้า `develop`
+4. รอ review จากเพื่อนในกลุ่มก่อน merge

--- a/handlers/notification.go
+++ b/handlers/notification.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 )
 
 type Notification struct {
@@ -18,7 +20,51 @@ func GetNotifications(w http.ResponseWriter, r *http.Request) {
 }
 
 func NotificationHandler(w http.ResponseWriter, r *http.Request) {
-	json.NewEncoder(w).Encode(map[string]string{
-		"message": "not implemented yet",
-	})
+	path := strings.TrimPrefix(r.URL.Path, "/api/notifications/")
+	parts := strings.Split(path, "/")
+
+	// DELETE /api/notifications/:id
+	if r.Method == http.MethodDelete && len(parts) == 1 && parts[0] != "" {
+		id, err := strconv.Atoi(parts[0])
+		if err != nil {
+			http.Error(w, "invalid id", http.StatusBadRequest)
+			return
+		}
+		for i, n := range notifications {
+			if n.ID == id {
+				notifications = append(notifications[:i], notifications[i+1:]...)
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+		}
+		http.NotFound(w, r)
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
+func SendNotification(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Message == "" {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	n := Notification{
+		ID:      len(notifications) + 1,
+		Message: body.Message,
+		Read:    false,
+	}
+	notifications = append(notifications, n)
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(n)
 }

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 	http.HandleFunc("/api/manage/queues/", handlers.ManageHandler)
 
 	http.HandleFunc("/api/notifications", handlers.GetNotifications)
+	http.HandleFunc("/api/notifications/send", handlers.SendNotification)
 	http.HandleFunc("/api/notifications/", handlers.NotificationHandler)
 
 	log.Println("Server running on port 3000")


### PR DESCRIPTION
## สรุปงาน
Implements งานของกิตติภณ คำนวล ตาม Issue #6

## Changes
- `DELETE /api/notifications/:id` — ลบแจ้งเตือนตาม id
- `POST /api/notifications/send` — ส่งการแจ้งเตือนใหม่เข้าระบบ
- เพิ่ม route `/api/notifications/send` ใน `main.go`
- อัปเดต `README.md` — แบ่งงานสมาชิกและ API documentation

## Endpoints
| Method | Endpoint | Status |
|--------|----------|--------|
| `DELETE` | `/api/notifications/:id` | ✅ Done |
| `POST` | `/api/notifications/send` | ✅ Done |

## Test checklist
- [ ] `DELETE` คืน 204 เมื่อ id ถูกต้อง
- [ ] `DELETE` คืน 404 เมื่อไม่พบ id
- [ ] `POST /send` คืน 201 พร้อม notification object
- [ ] `POST /send` คืน 400 เมื่อ body ไม่ถูกต้อง

Closes #6