### PR TITLE
feat(security): add OTP rate limiting middleware

### DIFF
--- a/internal/middleware/rate_limit.go
+++ b/internal/middleware/rate_limit.go
@@ -1,0 +1,89 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type rateLimitEntry struct {
+	count     int
+	windowEnd time.Time
+}
+
+type RateLimiter struct {
+	mu       sync.Mutex
+	store    map[string]*rateLimitEntry
+	limit    int
+	window   time.Duration
+}
+
+func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
+	rl := &RateLimiter{
+		store:  make(map[string]*rateLimitEntry),
+		limit:  limit,
+		window: window,
+	}
+	go rl.cleanup()
+	return rl
+}
+
+func (rl *RateLimiter) cleanup() {
+	ticker := time.NewTicker(rl.window)
+	defer ticker.Stop()
+	for range ticker.C {
+		rl.mu.Lock()
+		now := time.Now()
+		for key, entry := range rl.store {
+			if now.After(entry.windowEnd) {
+				delete(rl.store, key)
+			}
+		}
+		rl.mu.Unlock()
+	}
+}
+
+func (rl *RateLimiter) Allow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	entry, exists := rl.store[key]
+
+	if !exists || now.After(entry.windowEnd) {
+		rl.store[key] = &rateLimitEntry{
+			count:     1,
+			windowEnd: now.Add(rl.window),
+		}
+		return true
+	}
+
+	if entry.count >= rl.limit {
+		return false
+	}
+
+	entry.count++
+	return true
+}
+
+func (rl *RateLimiter) Middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ip := c.ClientIP()
+		if !rl.Allow(ip) {
+			c.JSON(http.StatusTooManyRequests, gin.H{
+				"error": "too many requests, please try again later",
+			})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
+// OTPRequestLimiter limits OTP requests: 5 per 10 minutes per IP
+var OTPRequestLimiter = NewRateLimiter(5, 10*time.Minute)
+
+// OTPVerifyLimiter limits OTP verify attempts: 10 per 10 minutes per IP
+var OTPVerifyLimiter = NewRateLimiter(10, 10*time.Minute)

--- a/internal/middleware/rate_limit_test.go
+++ b/internal/middleware/rate_limit_test.go
@@ -1,0 +1,91 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestRateLimiter_Allow(t *testing.T) {
+	rl := NewRateLimiter(3, 10*time.Second)
+
+	assert.True(t, rl.Allow("ip1"))
+	assert.True(t, rl.Allow("ip1"))
+	assert.True(t, rl.Allow("ip1"))
+	assert.False(t, rl.Allow("ip1")) // 4th should be blocked
+}
+
+func TestRateLimiter_DifferentKeys(t *testing.T) {
+	rl := NewRateLimiter(2, 10*time.Second)
+
+	assert.True(t, rl.Allow("ip1"))
+	assert.True(t, rl.Allow("ip1"))
+	assert.False(t, rl.Allow("ip1"))
+
+	// Different IP should have its own counter
+	assert.True(t, rl.Allow("ip2"))
+	assert.True(t, rl.Allow("ip2"))
+	assert.False(t, rl.Allow("ip2"))
+}
+
+func TestRateLimiter_WindowReset(t *testing.T) {
+	rl := NewRateLimiter(2, 50*time.Millisecond)
+
+	assert.True(t, rl.Allow("ip1"))
+	assert.True(t, rl.Allow("ip1"))
+	assert.False(t, rl.Allow("ip1"))
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Window should have reset
+	assert.True(t, rl.Allow("ip1"))
+}
+
+func TestRateLimiter_Middleware_Allow(t *testing.T) {
+	rl := NewRateLimiter(3, 10*time.Second)
+
+	r := gin.New()
+	r.POST("/test", rl.Middleware(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/test", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+}
+
+func TestRateLimiter_Middleware_Block(t *testing.T) {
+	rl := NewRateLimiter(2, 10*time.Second)
+
+	r := gin.New()
+	r.POST("/test", rl.Middleware(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	for i := 0; i < 2; i++ {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/test", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// 3rd request should be blocked
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/test", nil)
+	req.RemoteAddr = "1.2.3.4:1234"
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -26,9 +26,9 @@ func Setup(
 
 	api := r.Group("/api")
 
-	// Public Auth routes
-	api.POST("/auth/request-otp", auth.RequestOTP)
-	api.POST("/auth/verify-otp", auth.VerifyOTP)
+	// Public Auth routes (rate limited)
+	api.POST("/auth/request-otp", middleware.OTPRequestLimiter.Middleware(), auth.RequestOTP)
+	api.POST("/auth/verify-otp", middleware.OTPVerifyLimiter.Middleware(), auth.VerifyOTP)
 	api.POST("/auth/register", auth.Register)
 
 	// Protected routes


### PR DESCRIPTION
## Summary
- เพิ่ม in-memory rate limiter middleware ป้องกัน OTP flood attack
- `/auth/request-otp` จำกัด **5 ครั้ง / 10 นาที** ต่อ IP
- `/auth/verify-otp` จำกัด **10 ครั้ง / 10 นาที** ต่อ IP (ป้องกัน brute force)
- มี background cleanup goroutine ล้าง expired entries อัตโนมัติ

## Test plan
- [x] `TestRateLimiter_Allow` — อนุญาตภายใน limit
- [x] `TestRateLimiter_DifferentKeys` — แต่ละ IP มี counter แยกกัน
- [x] `TestRateLimiter_WindowReset` — reset หลังหมด window
- [x] `TestRateLimiter_Middleware_Allow` — middleware ผ่านภายใน limit
- [x] `TestRateLimiter_Middleware_Block` — middleware block เมื่อเกิน limit (429)