### PR TITLE
fix: queue numbering per zone, rate limiter max size, FindByQueueNumb…

### DIFF
--- a/internal/domain/queue.go
+++ b/internal/domain/queue.go
@@ -27,7 +27,7 @@ type Queue struct {
 type QueueRepository interface {
 	FindZoneByID(ctx context.Context, id uint) (*Zone, error)
 	CreateWithNextQueueNumber(ctx context.Context, queue *Queue) error
-	FindByQueueNumber(ctx context.Context, queueNumber int) (*Queue, error)
+	FindByQueueNumber(ctx context.Context, queueNumber int, userID uint) (*Queue, error)
 	FindByID(ctx context.Context, id uint) (*Queue, error)
 	FindByUserID(ctx context.Context, userID uint, offset, limit int) ([]Queue, error)
 	CountByUserID(ctx context.Context, userID uint) (int64, error)

--- a/internal/handler/queue_handler.go
+++ b/internal/handler/queue_handler.go
@@ -107,8 +107,6 @@ func (h *QueueHandler) GetQueue(c *gin.Context) {
 			respondError(c, http.StatusBadRequest, "INVALID_INPUT", err.Error())
 		case errors.Is(err, service.ErrQueueNotFound):
 			respondError(c, http.StatusNotFound, "QUEUE_NOT_FOUND", err.Error())
-		case errors.Is(err, service.ErrForbiddenQueue):
-			respondError(c, http.StatusForbidden, "FORBIDDEN", err.Error())
 		default:
 			respondError(c, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR", "internal server error")
 		}

--- a/internal/middleware/rate_limit.go
+++ b/internal/middleware/rate_limit.go
@@ -15,18 +15,22 @@ type rateLimitEntry struct {
 	windowEnd time.Time
 }
 
+const defaultMaxSize = 10_000
+
 type RateLimiter struct {
-	mu     sync.Mutex
-	store  map[string]*rateLimitEntry
-	limit  int
-	window time.Duration
+	mu      sync.Mutex
+	store   map[string]*rateLimitEntry
+	limit   int
+	window  time.Duration
+	maxSize int
 }
 
 func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
 	rl := &RateLimiter{
-		store:  make(map[string]*rateLimitEntry),
-		limit:  limit,
-		window: window,
+		store:   make(map[string]*rateLimitEntry),
+		limit:   limit,
+		window:  window,
+		maxSize: defaultMaxSize,
 	}
 	go rl.cleanup()
 	return rl
@@ -55,6 +59,9 @@ func (rl *RateLimiter) Allow(key string) bool {
 	entry, exists := rl.store[key]
 
 	if !exists || now.After(entry.windowEnd) {
+		if !exists && len(rl.store) >= rl.maxSize {
+			return false
+		}
 		rl.store[key] = &rateLimitEntry{
 			count:     1,
 			windowEnd: now.Add(rl.window),

--- a/internal/repository/queue_repository.go
+++ b/internal/repository/queue_repository.go
@@ -27,12 +27,13 @@ func (r *queueRepository) FindZoneByID(ctx context.Context, id uint) (*domain.Zo
 
 func (r *queueRepository) CreateWithNextQueueNumber(ctx context.Context, queue *domain.Queue) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", int64(1001)).Error; err != nil { //nolint:gosec // G201: hardcoded lock key, not user input
+		lockKey := int64(queue.ZoneID) //#nosec G115
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", lockKey).Error; err != nil {
 			return err
 		}
 
 		var last domain.Queue
-		err := tx.Order("queue_number desc").First(&last).Error
+		err := tx.Where("zone_id = ?", queue.ZoneID).Order("queue_number desc").First(&last).Error
 		if err != nil && err != gorm.ErrRecordNotFound {
 			return err
 		}
@@ -46,11 +47,11 @@ func (r *queueRepository) CreateWithNextQueueNumber(ctx context.Context, queue *
 	})
 }
 
-func (r *queueRepository) FindByQueueNumber(ctx context.Context, queueNumber int) (*domain.Queue, error) {
+func (r *queueRepository) FindByQueueNumber(ctx context.Context, queueNumber int, userID uint) (*domain.Queue, error) {
 	var queue domain.Queue
 	err := r.db.WithContext(ctx).
 		Preload("Zone").
-		Where("queue_number = ?", queueNumber).
+		Where("queue_number = ? AND user_id = ?", queueNumber, userID).
 		Order("created_at desc").
 		First(&queue).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/service/queue_service.go
+++ b/internal/service/queue_service.go
@@ -64,15 +64,12 @@ func (s *queueService) GetQueueByNumber(ctx context.Context, queueNumber int, us
 		return nil, ErrInvalidUserID
 	}
 
-	queue, err := s.repo.FindByQueueNumber(ctx, queueNumber)
+	queue, err := s.repo.FindByQueueNumber(ctx, queueNumber, userID)
 	if err != nil {
 		if errors.Is(err, domain.ErrQueueRecordNotFound) {
 			return nil, ErrQueueNotFound
 		}
 		return nil, err
-	}
-	if queue.UserID != userID {
-		return nil, ErrForbiddenQueue
 	}
 	return queue, nil
 }

--- a/internal/service/queue_service_test.go
+++ b/internal/service/queue_service_test.go
@@ -71,12 +71,12 @@ func (m *mockQueueRepo) CreateWithNextQueueNumber(_ context.Context, q *domain.Q
 	return nil
 }
 
-func (m *mockQueueRepo) FindByQueueNumber(_ context.Context, qn int) (*domain.Queue, error) {
+func (m *mockQueueRepo) FindByQueueNumber(_ context.Context, qn int, userID uint) (*domain.Queue, error) {
 	if m.findByNumErr != nil {
 		return nil, m.findByNumErr
 	}
 	for _, q := range m.queues {
-		if q.QueueNumber == qn {
+		if q.QueueNumber == qn && q.UserID == userID {
 			cp := *q
 			return &cp, nil
 		}
@@ -281,13 +281,13 @@ func TestGetQueueByNumber_GenericError(t *testing.T) {
 	}
 }
 
-func TestGetQueueByNumber_Forbidden(t *testing.T) {
+func TestGetQueueByNumber_NotOwner(t *testing.T) {
 	svc := newService()
 
 	_, err := svc.GetQueueByNumber(context.Background(), 5, 99) // queue 5 เป็นของ userID=88
 
-	if !errors.Is(err, ErrForbiddenQueue) {
-		t.Fatalf("expected ErrForbiddenQueue, got: %v", err)
+	if !errors.Is(err, ErrQueueNotFound) {
+		t.Fatalf("expected ErrQueueNotFound, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
…er scope

- fix CreateWithNextQueueNumber to query max queue_number within zone only
- change advisory lock key from global 1001 to zone ID for per-zone locking
- fix FindByQueueNumber to filter by user_id to prevent cross-zone queue collision
- add maxSize (10,000) to RateLimiter to prevent unbounded map growth under DDoS