### PR TITLE
fix(test): remove ErrForbiddenQueue case from GetQueue error mapping …

### DIFF
--- a/internal/handler/queue_handler_test.go
+++ b/internal/handler/queue_handler_test.go
@@ -337,7 +337,6 @@ func TestGetQueueErrorMappings(t *testing.T) {
 	}{
 		{"invalid user", service.ErrInvalidUserID, http.StatusBadRequest},
 		{"not found", service.ErrQueueNotFound, http.StatusNotFound},
-		{"forbidden", service.ErrForbiddenQueue, http.StatusForbidden},
 		{"internal", errors.New("boom"), http.StatusInternalServerError},
 	}
 


### PR DESCRIPTION
…test

GetQueue now returns 404 instead of 403 when queue belongs to another user ownership check moved to DB query in PR #55