### PR TITLE
test: increase overall coverage from 66.4% to 83.5%

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLoad_Defaults(t *testing.T) {
+	// Clear env vars to test defaults
+	os.Unsetenv("PORT")
+	os.Unsetenv("DATABASE_URL")
+	os.Unsetenv("JWT_SECRET")
+	os.Unsetenv("APP_ENV")
+	os.Unsetenv("OTP_CLEANUP_INTERVAL")
+
+	cfg := Load()
+
+	if cfg.Port != "3000" {
+		t.Errorf("expected port 3000, got %s", cfg.Port)
+	}
+	if cfg.DSN != "" {
+		t.Errorf("expected empty DSN, got %s", cfg.DSN)
+	}
+	if cfg.AppEnv != "production" {
+		t.Errorf("expected production, got %s", cfg.AppEnv)
+	}
+	if cfg.OTPCleanupInterval != "1h" {
+		t.Errorf("expected 1h, got %s", cfg.OTPCleanupInterval)
+	}
+	if cfg.BootstrapAdminName != "Bootstrap Admin" {
+		t.Errorf("expected Bootstrap Admin, got %s", cfg.BootstrapAdminName)
+	}
+	if cfg.BootstrapProviderName != "Bootstrap Provider" {
+		t.Errorf("expected Bootstrap Provider, got %s", cfg.BootstrapProviderName)
+	}
+}
+
+func TestLoad_FromEnv(t *testing.T) {
+	os.Setenv("PORT", "8080")
+	os.Setenv("DATABASE_URL", "postgres://localhost/test")
+	os.Setenv("JWT_SECRET", "mysecret")
+	os.Setenv("APP_ENV", "dev")
+	defer func() {
+		os.Unsetenv("PORT")
+		os.Unsetenv("DATABASE_URL")
+		os.Unsetenv("JWT_SECRET")
+		os.Unsetenv("APP_ENV")
+	}()
+
+	cfg := Load()
+
+	if cfg.Port != "8080" {
+		t.Errorf("expected 8080, got %s", cfg.Port)
+	}
+	if cfg.DSN != "postgres://localhost/test" {
+		t.Errorf("expected postgres URL, got %s", cfg.DSN)
+	}
+	if cfg.JWTSecret != "mysecret" {
+		t.Errorf("expected mysecret, got %s", cfg.JWTSecret)
+	}
+	if cfg.AppEnv != "dev" {
+		t.Errorf("expected dev, got %s", cfg.AppEnv)
+	}
+}
+
+func TestExposeOTPInResponse(t *testing.T) {
+	cases := []struct {
+		env      string
+		expected bool
+	}{
+		{"dev", true},
+		{"development", true},
+		{"test", true},
+		{"DEV", true},
+		{"DEVELOPMENT", true},
+		{"TEST", true},
+		{"production", false},
+		{"staging", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		cfg := &Config{AppEnv: tc.env}
+		got := cfg.ExposeOTPInResponse()
+		if got != tc.expected {
+			t.Errorf("AppEnv=%q: expected %v, got %v", tc.env, tc.expected, got)
+		}
+	}
+}
+
+func TestParsedOTPCleanupInterval_Valid(t *testing.T) {
+	cfg := &Config{OTPCleanupInterval: "30m"}
+	d := cfg.ParsedOTPCleanupInterval()
+	if d != 30*time.Minute {
+		t.Errorf("expected 30m, got %v", d)
+	}
+}
+
+func TestParsedOTPCleanupInterval_Invalid(t *testing.T) {
+	cfg := &Config{OTPCleanupInterval: "invalid"}
+	d := cfg.ParsedOTPCleanupInterval()
+	if d != time.Hour {
+		t.Errorf("expected fallback 1h, got %v", d)
+	}
+}
+
+func TestParsedOTPCleanupInterval_Various(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"1h", time.Hour},
+		{"24h", 24 * time.Hour},
+		{"5m", 5 * time.Minute},
+		{"10s", 10 * time.Second},
+	}
+
+	for _, tc := range cases {
+		cfg := &Config{OTPCleanupInterval: tc.input}
+		got := cfg.ParsedOTPCleanupInterval()
+		if got != tc.expected {
+			t.Errorf("input=%q: expected %v, got %v", tc.input, tc.expected, got)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
@@ -44,6 +45,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
@@ -65,4 +67,5 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/sqlite v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
@@ -67,6 +69,7 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -84,6 +87,8 @@ github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -191,5 +196,7 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/postgres v1.6.0 h1:2dxzU8xJ+ivvqTRph34QX+WrRaJlmfyPqXmoGVjMBa4=
 gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXDhtWo=
+gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=
+gorm.io/driver/sqlite v1.6.0/go.mod h1:AO9V1qIQddBESngQUKWL9yoH93HIeA1X6V633rBwyT8=
 gorm.io/gorm v1.31.1 h1:7CA8FTFz/gRfgqgpeKIBcervUn3xSyPUmr6B2WXJ7kg=
 gorm.io/gorm v1.31.1/go.mod h1:XyQVbO2k6YkOis7C2437jSit3SsDK72s7n7rsSHd+Gs=

--- a/internal/httpresponse/error_test.go
+++ b/internal/httpresponse/error_test.go
@@ -1,0 +1,64 @@
+package httpresponse
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("GET", "/api/test", nil)
+
+	Error(c, http.StatusBadRequest, "VALIDATION_ERROR", "phone is required")
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body["error"] != "VALIDATION_ERROR" {
+		t.Errorf("expected error VALIDATION_ERROR, got %v", body["error"])
+	}
+	if body["message"] != "phone is required" {
+		t.Errorf("expected message 'phone is required', got %v", body["message"])
+	}
+	if body["path"] != "/api/test" {
+		t.Errorf("expected path /api/test, got %v", body["path"])
+	}
+}
+
+func TestError_StatusCodes(t *testing.T) {
+	cases := []struct {
+		status int
+		code   string
+	}{
+		{http.StatusUnauthorized, "UNAUTHORIZED"},
+		{http.StatusForbidden, "FORBIDDEN"},
+		{http.StatusNotFound, "NOT_FOUND"},
+		{http.StatusInternalServerError, "INTERNAL_ERROR"},
+	}
+
+	for _, tc := range cases {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest("GET", "/test", nil)
+
+		Error(c, tc.status, tc.code, "test message")
+
+		if w.Code != tc.status {
+			t.Errorf("expected %d, got %d", tc.status, w.Code)
+		}
+	}
+}

--- a/internal/jwt/jwt_test.go
+++ b/internal/jwt/jwt_test.go
@@ -1,0 +1,91 @@
+package jwt
+
+import (
+	"testing"
+	"time"
+
+	gojwt "github.com/golang-jwt/jwt/v5"
+)
+
+func TestNewJWTManager(t *testing.T) {
+	m := NewJWTManager("mysecret")
+	if m == nil {
+		t.Error("expected non-nil JWTManager")
+	}
+}
+
+func TestGenerateAndValidateToken(t *testing.T) {
+	m := NewJWTManager("supersecretkey")
+
+	token, err := m.GenerateToken(1, "0812345678", "user")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	claims, err := m.ValidateToken(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if claims.UserID != 1 {
+		t.Errorf("expected UserID 1, got %d", claims.UserID)
+	}
+	if claims.Phone != "0812345678" {
+		t.Errorf("expected phone 0812345678, got %s", claims.Phone)
+	}
+	if claims.Role != "user" {
+		t.Errorf("expected role user, got %s", claims.Role)
+	}
+}
+
+func TestValidateToken_InvalidToken(t *testing.T) {
+	m := NewJWTManager("supersecretkey")
+
+	_, err := m.ValidateToken("not.a.valid.token")
+	if err == nil {
+		t.Error("expected error for invalid token")
+	}
+}
+
+func TestValidateToken_WrongSecret(t *testing.T) {
+	m1 := NewJWTManager("secret1")
+	m2 := NewJWTManager("secret2")
+
+	token, _ := m1.GenerateToken(1, "0812345678", "user")
+	_, err := m2.ValidateToken(token)
+	if err == nil {
+		t.Error("expected error for wrong secret")
+	}
+}
+
+func TestValidateToken_ExpiredToken(t *testing.T) {
+	m := NewJWTManager("supersecretkey")
+
+	claims := &Claims{
+		UserID: 1,
+		Phone:  "0812345678",
+		Role:   "user",
+		RegisteredClaims: gojwt.RegisteredClaims{
+			ExpiresAt: gojwt.NewNumericDate(time.Now().Add(-1 * time.Hour)),
+			IssuedAt:  gojwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+		},
+	}
+	token := gojwt.NewWithClaims(gojwt.SigningMethodHS256, claims)
+	tokenStr, _ := token.SignedString([]byte("supersecretkey"))
+
+	_, err := m.ValidateToken(tokenStr)
+	if err == nil {
+		t.Error("expected error for expired token")
+	}
+}
+
+func TestValidateToken_Malformed(t *testing.T) {
+	m := NewJWTManager("supersecretkey")
+
+	_, err := m.ValidateToken("aaa.bbb.ccc")
+	if err == nil {
+		t.Error("expected error for malformed token")
+	}
+}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -1,0 +1,164 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"qflow/internal/jwt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupJWT() *jwt.JWTManager {
+	return jwt.NewJWTManager("testsecretkey")
+}
+
+func TestJWTAuth_NoHeader(t *testing.T) {
+	jm := setupJWT()
+	r := gin.New()
+	r.GET("/", JWTAuth(jm), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestJWTAuth_InvalidFormat(t *testing.T) {
+	jm := setupJWT()
+	r := gin.New()
+	r.GET("/", JWTAuth(jm), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	cases := []string{
+		"InvalidToken",
+		"Token abc",
+		"Bearer",
+		"Bearer a b",
+	}
+
+	for _, h := range cases {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", h)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code, "header: %s", h)
+	}
+}
+
+func TestJWTAuth_InvalidToken(t *testing.T) {
+	jm := setupJWT()
+	r := gin.New()
+	r.GET("/", JWTAuth(jm), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer not.valid.token")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestJWTAuth_ValidToken(t *testing.T) {
+	jm := setupJWT()
+	token, _ := jm.GenerateToken(42, "0812345678", "user")
+
+	r := gin.New()
+	r.GET("/", JWTAuth(jm), func(c *gin.Context) {
+		userID, _ := c.Get("user_id")
+		role, _ := c.Get("role")
+		c.JSON(http.StatusOK, gin.H{"user_id": userID, "role": role})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRequireRole_NoRoleInContext(t *testing.T) {
+	r := gin.New()
+	r.GET("/", RequireRole("admin"), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestRequireRole_WrongRole(t *testing.T) {
+	r := gin.New()
+	r.GET("/", func(c *gin.Context) {
+		c.Set("role", "user")
+		c.Next()
+	}, RequireRole("admin"), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestRequireRole_CorrectRole(t *testing.T) {
+	r := gin.New()
+	r.GET("/", func(c *gin.Context) {
+		c.Set("role", "admin")
+		c.Next()
+	}, RequireRole("admin"), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRequireRole_MultipleRoles(t *testing.T) {
+	r := gin.New()
+	r.GET("/", func(c *gin.Context) {
+		c.Set("role", "provider")
+		c.Next()
+	}, RequireRole("admin", "provider"), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRequireRole_InvalidRoleType(t *testing.T) {
+	r := gin.New()
+	r.GET("/", func(c *gin.Context) {
+		c.Set("role", 12345) // wrong type
+		c.Next()
+	}, RequireRole("admin"), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/internal/repository/auth_repository_test.go
+++ b/internal/repository/auth_repository_test.go
@@ -1,0 +1,179 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"qflow/internal/domain"
+)
+
+func TestAuthRepo_CreateOTP(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewAuthRepository(db)
+	ctx := context.Background()
+
+	otp, err := repo.CreateOTP(ctx, "0812345678")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if otp.ID == 0 {
+		t.Error("expected OTP to have ID")
+	}
+	if len(otp.Code) != 6 {
+		t.Errorf("expected 6-digit code, got %s", otp.Code)
+	}
+	if otp.Used {
+		t.Error("new OTP should not be used")
+	}
+}
+
+func TestAuthRepo_FindValidOTP(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewAuthRepository(db)
+	ctx := context.Background()
+
+	otp, _ := repo.CreateOTP(ctx, "0812345678")
+
+	found, err := repo.FindValidOTP(ctx, "0812345678", otp.Code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.ID != otp.ID {
+		t.Errorf("expected ID %d, got %d", otp.ID, found.ID)
+	}
+}
+
+func TestAuthRepo_FindValidOTP_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewAuthRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindValidOTP(ctx, "0812345678", "000000")
+	if err == nil {
+		t.Error("expected error for non-existent OTP")
+	}
+}
+
+func TestAuthRepo_MarkOTPAsUsed(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewAuthRepository(db)
+	ctx := context.Background()
+
+	otp, _ := repo.CreateOTP(ctx, "0812345678")
+
+	err := repo.MarkOTPAsUsed(ctx, otp.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Mark again should fail (already used)
+	err = repo.MarkOTPAsUsed(ctx, otp.ID)
+	if err != domain.ErrOTPAlreadyUsed {
+		t.Errorf("expected ErrOTPAlreadyUsed, got %v", err)
+	}
+}
+
+func TestAuthRepo_DeleteExpiredOTPs(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewAuthRepository(db)
+	ctx := context.Background()
+
+	// Create an expired OTP directly via db
+	db.Create(&domain.OTP{
+		Phone:     "0812345678",
+		Code:      "123456",
+		ExpiresAt: time.Now().Add(-1 * time.Hour),
+		Used:      false,
+	})
+
+	n, err := repo.DeleteExpiredOTPs(ctx, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 deleted, got %d", n)
+	}
+}
+
+func TestAuthRepo_CreateAndFindUser(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewAuthRepository(db)
+	ctx := context.Background()
+
+	user := &domain.User{Phone: "0812345678", Name: "Test", Role: "user"}
+	err := repo.CreateUser(ctx, user)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.ID == 0 {
+		t.Error("expected user to have ID")
+	}
+
+	found, err := repo.FindUserByPhone(ctx, "0812345678")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.Name != "Test" {
+		t.Errorf("expected name Test, got %s", found.Name)
+	}
+}
+
+func TestAuthRepo_FindUserByPhone_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewAuthRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindUserByPhone(ctx, "0000000000")
+	if err == nil {
+		t.Error("expected error for non-existent user")
+	}
+}
+
+func TestAuthRepo_FindUserByID(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewAuthRepository(db)
+	ctx := context.Background()
+
+	user := &domain.User{Phone: "0812345678", Name: "Test", Role: "user"}
+	repo.CreateUser(ctx, user)
+
+	found, err := repo.FindUserByID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.ID != user.ID {
+		t.Errorf("expected ID %d, got %d", user.ID, found.ID)
+	}
+}
+
+func TestAuthRepo_FindUserByID_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewAuthRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindUserByID(ctx, 9999)
+	if err == nil {
+		t.Error("expected error for non-existent user")
+	}
+}
+
+func TestAuthRepo_UpdateUser(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewAuthRepository(db)
+	ctx := context.Background()
+
+	user := &domain.User{Phone: "0812345678", Name: "Old", Role: "user"}
+	repo.CreateUser(ctx, user)
+
+	user.Name = "New"
+	err := repo.UpdateUser(ctx, user)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found, _ := repo.FindUserByID(ctx, user.ID)
+	if found.Name != "New" {
+		t.Errorf("expected name New, got %s", found.Name)
+	}
+}

--- a/internal/repository/category_repository_test.go
+++ b/internal/repository/category_repository_test.go
@@ -1,0 +1,166 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"qflow/internal/domain"
+)
+
+func TestCategoryRepo_CreateAndFind(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewCategoryGormRepository(db)
+	ctx := context.Background()
+
+	err := repo.Create(ctx, &domain.Category{Name: "Hospital"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cats, err := repo.FindAll(ctx, 0, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cats) != 1 {
+		t.Errorf("expected 1 category, got %d", len(cats))
+	}
+}
+
+func TestCategoryRepo_Count(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewCategoryGormRepository(db)
+	ctx := context.Background()
+
+	repo.Create(ctx, &domain.Category{Name: "A"})
+	repo.Create(ctx, &domain.Category{Name: "B"})
+
+	n, err := repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected 2, got %d", n)
+	}
+}
+
+func TestCategoryRepo_FindByID(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewCategoryGormRepository(db)
+	ctx := context.Background()
+
+	cat := &domain.Category{Name: "Clinic"}
+	repo.Create(ctx, cat)
+
+	found, err := repo.FindByID(ctx, cat.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.Name != "Clinic" {
+		t.Errorf("expected Clinic, got %s", found.Name)
+	}
+}
+
+func TestCategoryRepo_FindByID_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewCategoryGormRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindByID(ctx, 9999)
+	if err != domain.ErrCategoryRecordNotFound {
+		t.Errorf("expected ErrCategoryRecordNotFound, got %v", err)
+	}
+}
+
+func TestCategoryRepo_Update(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewCategoryGormRepository(db)
+	ctx := context.Background()
+
+	cat := &domain.Category{Name: "Old"}
+	repo.Create(ctx, cat)
+
+	cat.Name = "New"
+	err := repo.Update(ctx, cat)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found, _ := repo.FindByID(ctx, cat.ID)
+	if found.Name != "New" {
+		t.Errorf("expected New, got %s", found.Name)
+	}
+}
+
+func TestCategoryRepo_Delete(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewCategoryGormRepository(db)
+	ctx := context.Background()
+
+	cat := &domain.Category{Name: "ToDelete"}
+	repo.Create(ctx, cat)
+
+	err := repo.Delete(ctx, cat.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = repo.FindByID(ctx, cat.ID)
+	if err != domain.ErrCategoryRecordNotFound {
+		t.Errorf("expected not found after delete, got %v", err)
+	}
+}
+
+func TestCategoryRepo_Delete_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewCategoryGormRepository(db)
+	ctx := context.Background()
+
+	err := repo.Delete(ctx, 9999)
+	if err != domain.ErrCategoryRecordNotFound {
+		t.Errorf("expected ErrCategoryRecordNotFound, got %v", err)
+	}
+}
+
+func TestCategoryRepo_ExistsByName(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewCategoryGormRepository(db)
+	ctx := context.Background()
+
+	repo.Create(ctx, &domain.Category{Name: "Dental"})
+
+	exists, err := repo.ExistsByName(ctx, "dental") // lowercase
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Error("expected exists=true")
+	}
+
+	exists, err = repo.ExistsByName(ctx, "NonExistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists {
+		t.Error("expected exists=false")
+	}
+}
+
+func TestCategoryRepo_FindAll_Pagination(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewCategoryGormRepository(db)
+	ctx := context.Background()
+
+	for _, name := range []string{"A", "B", "C", "D", "E"} {
+		repo.Create(ctx, &domain.Category{Name: name})
+	}
+
+	page1, _ := repo.FindAll(ctx, 0, 3)
+	if len(page1) != 3 {
+		t.Errorf("expected 3, got %d", len(page1))
+	}
+
+	page2, _ := repo.FindAll(ctx, 3, 3)
+	if len(page2) != 2 {
+		t.Errorf("expected 2, got %d", len(page2))
+	}
+}

--- a/internal/repository/notification_repository_test.go
+++ b/internal/repository/notification_repository_test.go
@@ -1,0 +1,124 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"qflow/internal/domain"
+)
+
+func TestNotificationRepo_CreateAndFind(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewNotificationRepository(db)
+	ctx := context.Background()
+
+	n := &domain.Notification{UserID: 1, Message: "hello"}
+	err := repo.Create(ctx, n)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n.ID == 0 {
+		t.Error("expected ID to be set")
+	}
+}
+
+func TestNotificationRepo_FindByUserID(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewNotificationRepository(db)
+	ctx := context.Background()
+
+	repo.Create(ctx, &domain.Notification{UserID: 1, Message: "a"})
+	repo.Create(ctx, &domain.Notification{UserID: 1, Message: "b"})
+	repo.Create(ctx, &domain.Notification{UserID: 2, Message: "c"})
+
+	results, err := repo.FindByUserID(ctx, 1, 0, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2, got %d", len(results))
+	}
+}
+
+func TestNotificationRepo_CountByUserID(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewNotificationRepository(db)
+	ctx := context.Background()
+
+	repo.Create(ctx, &domain.Notification{UserID: 1, Message: "a"})
+	repo.Create(ctx, &domain.Notification{UserID: 1, Message: "b"})
+
+	count, err := repo.CountByUserID(ctx, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2, got %d", count)
+	}
+}
+
+func TestNotificationRepo_FindByID(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewNotificationRepository(db)
+	ctx := context.Background()
+
+	n := &domain.Notification{UserID: 1, Message: "test"}
+	repo.Create(ctx, n)
+
+	found, err := repo.FindByID(ctx, n.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.Message != "test" {
+		t.Errorf("expected test, got %s", found.Message)
+	}
+}
+
+func TestNotificationRepo_FindByID_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewNotificationRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindByID(ctx, 9999)
+	if err == nil {
+		t.Error("expected error for non-existent notification")
+	}
+}
+
+func TestNotificationRepo_MarkRead(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewNotificationRepository(db)
+	ctx := context.Background()
+
+	n := &domain.Notification{UserID: 1, Message: "test"}
+	repo.Create(ctx, n)
+
+	err := repo.MarkRead(ctx, n.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found, _ := repo.FindByID(ctx, n.ID)
+	if !found.IsRead {
+		t.Error("expected IsRead=true")
+	}
+}
+
+func TestNotificationRepo_Delete(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewNotificationRepository(db)
+	ctx := context.Background()
+
+	n := &domain.Notification{UserID: 1, Message: "test"}
+	repo.Create(ctx, n)
+
+	err := repo.Delete(ctx, n.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = repo.FindByID(ctx, n.ID)
+	if err == nil {
+		t.Error("expected error after delete")
+	}
+}

--- a/internal/repository/provider_repository_test.go
+++ b/internal/repository/provider_repository_test.go
@@ -1,0 +1,247 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"qflow/internal/domain"
+)
+
+func seedCategory(t *testing.T, db interface{ Create(ctx context.Context, c *domain.Category) error }) *domain.Category {
+	cat := &domain.Category{Name: "TestCat"}
+	if err := db.Create(context.Background(), cat); err != nil {
+		panic(err)
+	}
+	return cat
+}
+
+func TestProviderRepo_CreateAndFind(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	catID := uint(1)
+	err := repo.CreateProvider(ctx, &domain.Provider{Name: "ProvA", CategoryID: &catID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	providers, err := repo.FindProviders(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Errorf("expected 1, got %d", len(providers))
+	}
+}
+
+func TestProviderRepo_FindProviders_Empty(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	providers, err := repo.FindProviders(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(providers) != 0 {
+		t.Errorf("expected 0, got %d", len(providers))
+	}
+}
+
+func TestProviderRepo_FindCategoryByID(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	catRepo := NewCategoryGormRepository(db)
+	ctx := context.Background()
+
+	cat := &domain.Category{Name: "Health"}
+	catRepo.Create(ctx, cat)
+
+	found, err := repo.FindCategoryByID(ctx, cat.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.Name != "Health" {
+		t.Errorf("expected Health, got %s", found.Name)
+	}
+}
+
+func TestProviderRepo_FindCategoryByID_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindCategoryByID(ctx, 9999)
+	if err != domain.ErrProviderCategoryRecordNotFound {
+		t.Errorf("expected ErrProviderCategoryRecordNotFound, got %v", err)
+	}
+}
+
+func TestProviderRepo_FindProviderByID(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	p := &domain.Provider{Name: "ProvB"}
+	repo.CreateProvider(ctx, p)
+
+	found, err := repo.FindProviderByID(ctx, p.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.Name != "ProvB" {
+		t.Errorf("expected ProvB, got %s", found.Name)
+	}
+}
+
+func TestProviderRepo_FindProviderByID_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindProviderByID(ctx, 9999)
+	if err != domain.ErrProviderRecordNotFound {
+		t.Errorf("expected ErrProviderRecordNotFound, got %v", err)
+	}
+}
+
+func TestProviderRepo_CreateAndFindZone(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	p := &domain.Provider{Name: "ProvC"}
+	repo.CreateProvider(ctx, p)
+
+	zone := &domain.Zone{ProviderID: p.ID, Name: "Zone A", IsOpen: true}
+	err := repo.CreateZone(ctx, zone)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	zones, err := repo.FindZonesByProviderID(ctx, p.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(zones) != 1 {
+		t.Errorf("expected 1, got %d", len(zones))
+	}
+}
+
+func TestProviderRepo_FindZoneByID(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	p := &domain.Provider{Name: "ProvD"}
+	repo.CreateProvider(ctx, p)
+	zone := &domain.Zone{ProviderID: p.ID, Name: "Zone B"}
+	repo.CreateZone(ctx, zone)
+
+	found, err := repo.FindZoneByID(ctx, zone.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.Name != "Zone B" {
+		t.Errorf("expected Zone B, got %s", found.Name)
+	}
+}
+
+func TestProviderRepo_FindZoneByID_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindZoneByID(ctx, 9999)
+	if err != domain.ErrProviderZoneRecordNotFound {
+		t.Errorf("expected ErrProviderZoneRecordNotFound, got %v", err)
+	}
+}
+
+func TestProviderRepo_UpdateZone(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	p := &domain.Provider{Name: "ProvE"}
+	repo.CreateProvider(ctx, p)
+	zone := &domain.Zone{ProviderID: p.ID, Name: "Zone C", IsOpen: true}
+	repo.CreateZone(ctx, zone)
+
+	zone.IsOpen = false
+	err := repo.UpdateZone(ctx, zone)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found, _ := repo.FindZoneByID(ctx, zone.ID)
+	if found.IsOpen {
+		t.Error("expected IsOpen=false")
+	}
+}
+
+func TestProviderRepo_CountQueuesByZoneID(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	p := &domain.Provider{Name: "ProvF"}
+	repo.CreateProvider(ctx, p)
+	zone := &domain.Zone{ProviderID: p.ID, Name: "Zone D"}
+	repo.CreateZone(ctx, zone)
+
+	// Add queues directly
+	db.Create(&domain.Queue{ZoneID: zone.ID, UserID: 1, QueueNumber: 1, Status: "waiting"})
+	db.Create(&domain.Queue{ZoneID: zone.ID, UserID: 2, QueueNumber: 2, Status: "waiting"})
+
+	count, err := repo.CountQueuesByZoneID(ctx, zone.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2, got %d", count)
+	}
+}
+
+func TestProviderRepo_CountQueuesByZoneIDs(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	p := &domain.Provider{Name: "ProvG"}
+	repo.CreateProvider(ctx, p)
+	z1 := &domain.Zone{ProviderID: p.ID, Name: "Z1"}
+	z2 := &domain.Zone{ProviderID: p.ID, Name: "Z2"}
+	repo.CreateZone(ctx, z1)
+	repo.CreateZone(ctx, z2)
+
+	db.Create(&domain.Queue{ZoneID: z1.ID, UserID: 1, QueueNumber: 1, Status: "waiting"})
+	db.Create(&domain.Queue{ZoneID: z2.ID, UserID: 2, QueueNumber: 1, Status: "waiting"})
+	db.Create(&domain.Queue{ZoneID: z2.ID, UserID: 3, QueueNumber: 2, Status: "waiting"})
+
+	counts, err := repo.CountQueuesByZoneIDs(ctx, []uint{z1.ID, z2.ID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if counts[z1.ID] != 1 {
+		t.Errorf("expected 1 for z1, got %d", counts[z1.ID])
+	}
+	if counts[z2.ID] != 2 {
+		t.Errorf("expected 2 for z2, got %d", counts[z2.ID])
+	}
+}
+
+func TestProviderRepo_CountQueuesByZoneIDs_Empty(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewProviderRepository(db)
+	ctx := context.Background()
+
+	counts, err := repo.CountQueuesByZoneIDs(ctx, []uint{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(counts) != 0 {
+		t.Errorf("expected empty map, got %v", counts)
+	}
+}

--- a/internal/repository/provider_repository_test.go
+++ b/internal/repository/provider_repository_test.go
@@ -7,7 +7,9 @@ import (
 	"qflow/internal/domain"
 )
 
-func seedCategory(t *testing.T, db interface{ Create(ctx context.Context, c *domain.Category) error }) *domain.Category {
+func seedCategory(t *testing.T, db interface {
+	Create(ctx context.Context, c *domain.Category) error
+}) *domain.Category {
 	cat := &domain.Category{Name: "TestCat"}
 	if err := db.Create(context.Background(), cat); err != nil {
 		panic(err)

--- a/internal/repository/queue_repository_test.go
+++ b/internal/repository/queue_repository_test.go
@@ -1,0 +1,172 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"qflow/internal/domain"
+)
+
+func setupQueueTest(t *testing.T) (*domain.Zone, *domain.User, *queueRepository) {
+	db := newTestDB(t)
+	repo := NewQueueRepository(db).(*queueRepository)
+
+	user := &domain.User{Phone: "0812345678", Name: "Test", Role: "user"}
+	db.Create(user)
+
+	p := &domain.Provider{Name: "Prov"}
+	db.Create(p)
+
+	zone := &domain.Zone{ProviderID: p.ID, Name: "Zone A", IsOpen: true}
+	db.Create(zone)
+
+	return zone, user, repo
+}
+
+// insertQueue inserts a queue directly bypassing pg_advisory_xact_lock
+func insertQueue(t *testing.T, repo *queueRepository, zoneID, userID uint, num int, status string) *domain.Queue {
+	t.Helper()
+	q := &domain.Queue{ZoneID: zoneID, UserID: userID, QueueNumber: num, Status: status}
+	if err := repo.db.Create(q).Error; err != nil {
+		t.Fatalf("failed to insert queue: %v", err)
+	}
+	return q
+}
+
+func TestQueueRepo_FindZoneByID(t *testing.T) {
+	zone, _, repo := setupQueueTest(t)
+	ctx := context.Background()
+
+	found, err := repo.FindZoneByID(ctx, zone.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.ID != zone.ID {
+		t.Errorf("expected ID %d, got %d", zone.ID, found.ID)
+	}
+}
+
+func TestQueueRepo_FindZoneByID_NotFound(t *testing.T) {
+	_, _, repo := setupQueueTest(t)
+	ctx := context.Background()
+
+	_, err := repo.FindZoneByID(ctx, 9999)
+	if err != domain.ErrQueueZoneRecordNotFound {
+		t.Errorf("expected ErrQueueZoneRecordNotFound, got %v", err)
+	}
+}
+
+func TestQueueRepo_FindByQueueNumber(t *testing.T) {
+	zone, user, repo := setupQueueTest(t)
+	ctx := context.Background()
+
+	q := insertQueue(t, repo, zone.ID, user.ID, 1, "waiting")
+
+	found, err := repo.FindByQueueNumber(ctx, q.QueueNumber, user.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.ID != q.ID {
+		t.Errorf("expected ID %d, got %d", q.ID, found.ID)
+	}
+}
+
+func TestQueueRepo_FindByQueueNumber_NotFound(t *testing.T) {
+	_, user, repo := setupQueueTest(t)
+	ctx := context.Background()
+
+	_, err := repo.FindByQueueNumber(ctx, 9999, user.ID)
+	if err != domain.ErrQueueRecordNotFound {
+		t.Errorf("expected ErrQueueRecordNotFound, got %v", err)
+	}
+}
+
+func TestQueueRepo_FindByID(t *testing.T) {
+	zone, user, repo := setupQueueTest(t)
+	ctx := context.Background()
+
+	q := insertQueue(t, repo, zone.ID, user.ID, 1, "waiting")
+
+	found, err := repo.FindByID(ctx, q.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found.ID != q.ID {
+		t.Errorf("expected ID %d, got %d", q.ID, found.ID)
+	}
+}
+
+func TestQueueRepo_FindByID_NotFound(t *testing.T) {
+	_, _, repo := setupQueueTest(t)
+	ctx := context.Background()
+
+	_, err := repo.FindByID(ctx, 9999)
+	if err != domain.ErrQueueRecordNotFound {
+		t.Errorf("expected ErrQueueRecordNotFound, got %v", err)
+	}
+}
+
+func TestQueueRepo_FindByUserID(t *testing.T) {
+	zone, user, repo := setupQueueTest(t)
+	ctx := context.Background()
+
+	insertQueue(t, repo, zone.ID, user.ID, 1, "waiting")
+	insertQueue(t, repo, zone.ID, user.ID, 2, "waiting")
+
+	queues, err := repo.FindByUserID(ctx, user.ID, 0, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(queues) != 2 {
+		t.Errorf("expected 2, got %d", len(queues))
+	}
+}
+
+func TestQueueRepo_CountByUserID(t *testing.T) {
+	zone, user, repo := setupQueueTest(t)
+	ctx := context.Background()
+
+	insertQueue(t, repo, zone.ID, user.ID, 1, "waiting")
+	insertQueue(t, repo, zone.ID, user.ID, 2, "waiting")
+
+	count, err := repo.CountByUserID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2, got %d", count)
+	}
+}
+
+func TestQueueRepo_UpdateStatus(t *testing.T) {
+	zone, user, repo := setupQueueTest(t)
+	ctx := context.Background()
+
+	q := insertQueue(t, repo, zone.ID, user.ID, 1, "waiting")
+
+	err := repo.UpdateStatus(ctx, q.ID, "called")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found, _ := repo.FindByID(ctx, q.ID)
+	if found.Status != "called" {
+		t.Errorf("expected called, got %s", found.Status)
+	}
+}
+
+func TestQueueRepo_GetByZoneID(t *testing.T) {
+	zone, user, repo := setupQueueTest(t)
+	ctx := context.Background()
+
+	insertQueue(t, repo, zone.ID, user.ID, 1, "waiting")
+	insertQueue(t, repo, zone.ID, user.ID, 2, "called")
+
+	queues, err := repo.GetByZoneID(ctx, zone.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(queues) != 2 {
+		t.Errorf("expected 2, got %d", len(queues))
+	}
+}

--- a/internal/repository/testhelper_test.go
+++ b/internal/repository/testhelper_test.go
@@ -1,0 +1,40 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"qflow/internal/domain"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	err = db.AutoMigrate(
+		&domain.User{},
+		&domain.OTP{},
+		&domain.Category{},
+		&domain.Provider{},
+		&domain.Zone{},
+		&domain.Queue{},
+		&domain.Notification{},
+	)
+	if err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	return db
+}
+
+func mustTime(s string) time.Time {
+	t, _ := time.Parse(time.RFC3339, s)
+	return t
+}


### PR DESCRIPTION
Add unit tests for previously uncovered packages:
- config: 100% (Load, ExposeOTPInResponse, ParsedOTPCleanupInterval)
- httpresponse: 100% (Error with all status codes)
- jwt: 84.6% (GenerateToken, ValidateToken, expired/wrong secret)
- middleware/auth: 98.6% (JWTAuth, RequireRole all paths)
- repository: 87.3% (auth, category, notification, provider, queue)
  - Uses SQLite in-memory DB via gorm.io/driver/sqlite
  - Bypasses pg_advisory_xact_lock by inserting queues directly